### PR TITLE
ignore invalid and bogus addresses

### DIFF
--- a/antissh.py
+++ b/antissh.py
@@ -129,6 +129,10 @@ def main():
         match = IP_REGEX.search(text)
         if match:
             ip = match.group(1)
+            
+            if ip in ('0', '255.255.255.255', '127.0.0.1', '::1'):
+                return
+
             asyncio.ensure_future(check_connecting_client(bot, ip))
 
     asyncio.get_event_loop().run_forever()


### PR DESCRIPTION
excludes
  - 0 and 255.255.255.255 (happens with remote and locally spoofed clients)
  - 127.0.0.1 / ::1 (localhost)

