### PR TITLE
Fix erroneous regex matching of realname strings containing full stops

### DIFF
--- a/antissh.py
+++ b/antissh.py
@@ -46,7 +46,7 @@ if BINDHOST is not None:
 # *** REMOTECONNECT: Client connecting on port 6667 (class unnamed...): kaniini!kaniini@127.0.0.1 (127.0.0.1) [kaniini]
 # re.findall(r'\([0-9a-f\.:]+\)')
 
-IP_REGEX = re.compile(r'Client connecting\:.*\[([0-9a-f\.:]+)\]')
+IP_REGEX = re.compile(r'Client connecting\:.*\[([0-9a-f\.:]+)\].*{.*}.*')
 POSITIVE_HIT_STRING = b'Looking up your hostname'
 DEFAULT_CREDENTIALS = [
     ('ADMIN', 'ADMIN'),      # supermicro default IPMI


### PR DESCRIPTION
When the fullname that a connecting client presents contains only characters also matched by IP_REGEX (for example '...' as I see quite regularly) the IP address is not being extracted correctly from the connection notice:

```
DEBUG:asyncirc.IRCProtocol::irc.server NOTICE * :*** Notice -- Client connecting: Pice (~Pice@123.200.134.60) [123.200.134.60] {Users} [...] <BjD9x>
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
INFO:asyncssh:Opening SSH connection to ..., port 22
ERROR:asyncio:Task exception was never retrieved
future: <Task finished coro=<check_connecting_client() done, defined at /home/ngserv/antissh/antissh.py:223> exception=UnicodeError("encoding with 'idna' codec failed (UnicodeError: label empty or too long)",)>
Traceback (most recent call last):
  File "/usr/lib64/python3.6/encodings/idna.py", line 165, in encode
    raise UnicodeError("label empty or too long")
UnicodeError: label empty or too long

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ngserv/antissh/antissh.py", line 224, in check_connecting_client
    async def check_connecting_client(bot, ip):
  File "/home/ngserv/antissh/antissh.py", line 218, in check_with_credentials_group
    futures = [check_with_credentials(ip, target_ip, target_port, c[0], c[1]) for c in credentials_group]
  File "/home/ngserv/antissh/antissh.py", line 182, in check_with_credentials
    known_hosts=None, client_keys=None, client_host_keys=None,
  File "/usr/lib/python3.6/site-packages/asyncssh/misc.py", line 165, in __aenter__
    self._result = yield from self._coro
  File "/usr/lib/python3.6/site-packages/asyncssh/connection.py", line 5410, in connect
    conn, _ = yield from create_connection(None, host, port, **kwargs)
  File "/usr/lib/python3.6/site-packages/asyncssh/connection.py", line 5068, in create_connection
    local_addr=local_addr)
  File "/usr/lib64/python3.6/asyncio/base_events.py", line 734, in create_connection
    infos = f1.result()
  File "/usr/lib64/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib64/python3.6/socket.py", line 745, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
UnicodeError: encoding with 'idna' codec failed (UnicodeError: label empty or too long)
```

This regex change in the PR correctly fixes connections to ircu (which uses a very similar connection notice format to charybdis).